### PR TITLE
setValidationScope(false) FIX

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -318,7 +318,7 @@ $.nette.ext('redirect', {
 // change URL (requires HTML5)
 if (!!(window.history && history.pushState)) { // check borrowed from Modernizr
 	$.nette.ext('history', {
-		before: function (ui) {
+		before: function (settings, ui) {
 			var $el = $(ui);
 			if ($el.is('a')) {
 				this.href = ui.href;


### PR DESCRIPTION
$().attr('formnovalidate') returns empty string which is not true while && operation
