### PR TITLE
FIX: setValidationScope(FALSE) support

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -209,7 +209,7 @@ $.nette.ext('validation', {
 			} else if (explicitNoAjax) return false;
 		}
 
-		if (validate.form && analyze.form && !((analyze.isSubmit || analyze.isImage) && analyze.el.attr('formnovalidate'))) {
+		if (validate.form && analyze.form && !((analyze.isSubmit || analyze.isImage) && analyze.el.attr('formnovalidate') !== undefined)) {
 			if (analyze.form.get(0).onsubmit && !analyze.form.get(0).onsubmit()) {
 				e.stopImmediatePropagation();
 				e.preventDefault();


### PR DESCRIPTION
FIX: $(el).attr('formnovalidate') return empty string which does not act as true while && operation
