### PR TITLE
Submit detection: button (not input) with submit type is also valid

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -159,7 +159,7 @@ var nette = function () {
 				ui: ui,
 				el: $el,
 				isForm: $el.is('form'),
-				isSubmit: $el.is('input[type=submit]'),
+				isSubmit: $el.is('input[type=submit]') || $el.is('button[type=submit]'),
 				isImage: $el.is('input[type=image]'),
 				form: null
 			};


### PR DESCRIPTION
I use Twitter Bootstrap and for some submit buttons I want to add icon. However I have found now that some buttons are not detected.

For example:

``` html
<button type="submit" name="search-button">
    <i class="icon-search"></i>
</button>
```

This Pull Request solves this issue.
