### PR TITLE
History: fix onload popstate trigerring reload [Closes #61]

### DIFF
--- a/history/history.ajax.js
+++ b/history/history.ajax.js
@@ -43,7 +43,7 @@ $.nette.ext('history', {
 		}, document.title, window.location.href);
 
 		$(window).on('popstate.nette', $.proxy(function (e) {
-			var state = e.originalEvent.state || this.initialState;
+			var state = e.originalEvent.state;
 			if (window.history.ready || !state || !state.nette) return;
 			if (this.cache && state.ui) {
 				handleState(this, 'UI', [state.ui]);


### PR DESCRIPTION
Různý 3rd party obsah, konkrétně třeba embedded Youtube a Google custom search, nefunguje, protože se `popstate` pouští ve webkitu i na `onLoad` (http://stackoverflow.com/a/14150776/326257).

V `onLoad` fázi je `e.originalEvent.state === null` , takže se to dá odfiltrovat, z nějakého důvodu je tam ale

``` js
      var state = e.originalEvent.state || this.initialState;
```

Nejsem si úplně jistý, k čemu je tam ověřování `this.initialState`, ale podle mě to nic jiného nerozbilo.
