### PR TITLE
forms: password inputs cleared after submition

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -356,6 +356,8 @@ $.nette.ext('forms', {
 		}
 		formData = $.param(formData);
 		settings.data = analyze.form.serialize() + (formData ? '&' + formData : '') + '&' + originalData;
+
+		analyze.form.find('input[type="password"]').val('');
 	}
 });
 


### PR DESCRIPTION
I saw this thing at typo3 backoffice login form and thought to myself it's a nice pseudo-security feature just to clear the password input (but send its value anyway) just after I hit Enter...
