### PR TITLE
Add extended for bootstrap modal

### DIFF
--- a/extensions/modal.ajax.js
+++ b/extensions/modal.ajax.js
@@ -1,0 +1,25 @@
+(function($, undefined) {
+
+$.nette.ext({
+	before: function (xhr, settings) {
+		if (!settings.nette) {
+			return;
+		}
+		$.nette.ext('spinner', null);
+		this.el = settings.nette.el;
+	},
+	success: function(payload) {
+		var modal = this.el.data('toggle') == 'modal';
+		if (modal) {
+			var url = this.el.attr('href');
+			if (url.indexOf('#') == 0) {
+				$(url).modal('open');
+			} else {
+				$('<div class="modal hide fade">' + payload + '</div>').modal();
+			}
+		}
+		return false;
+	}
+});
+
+})(jQuery);


### PR DESCRIPTION
Pouziti pro otevreni formulare v modalnim okne Bootstrap:

```
<a href="{link edit, $countryId}" data-toggle="modal" class="ajax"><i class="icon-edit"></i> Upravit</a>
```

V action edit:

```
<div class="modal-header">
    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
    <h3 id="myModalLabel">Upravit</h3>
</div>
<div class="modal-body">
    {form editForm}
    {form controls}  
</div>
<div class="modal-footer">
    {input send}
    {input cancel, 'data-dismiss' => "modal"}
    {/form}
 </div>
```
