### PR TITLE
add XHR2 FormData support for ajax file upload

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -381,7 +381,7 @@ $.nette.ext('forms', {
 		}
 		
 		// https://developer.mozilla.org/en-US/docs/Web/Guide/Using_FormData_Objects#Sending_files_using_a_FormData_object
-		if ("FormData" in window) {
+		if (analyze.form.attr('method').toLowerCase() === 'post' && "FormData" in window) {
 			var formData2 = new FormData(analyze.form[0]);
 			for (var i in formData) {
 				formData2.append(i, formData[i]);


### PR DESCRIPTION
I found #83 so I tried to implement [xhr2 using FormData](https://developer.mozilla.org/en-US/docs/Web/Guide/Using_FormData_Objects#Sending_files_using_a_FormData_object)

Not sure how `originalData` should be handled, though. Any idea?
