### PR TITLE
Bower: updated nette-forms dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,6 @@
 	],
 	"dependencies": {
 		"jquery": ">=1.7.0",
-		"nette-forms": "~0.0.3"
+		"nette-forms": "~2.2"
 	}
 }


### PR DESCRIPTION
The `~0.0.3` version constraint doesn't make sense now that the current `nette-forms` bower reference points to `nette/forms` repository.
