### PR TITLE
Bower: extension files removed from ignore list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
 	"keywords": ["nette", "ajax", "jquery"],
 	"main": "nette.ajax.js",
 	"ignore": [
-		"extensions/*",
 		"CONTRIBUTING.md",
 		"example.js",
 		"readme.md"


### PR DESCRIPTION
I tried master and suddenly WebLoader was screaming that extension files were missing.
I do not know, if there is some purpose about listing extensions in ignore list, but if there is not, here is a pull request.