### PR TITLE
Fixed ajax calling by passing url string instead of settings object

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -154,6 +154,9 @@ var nette = function () {
 	 * @return {jqXHR|null}
 	 */
 	this.ajax = function (settings, ui, e) {
+		if ($.type(settings) === 'string') {
+			settings = {url: settings};
+		}
 		if (!settings.nette && ui && e) {
 			var $el = $(ui), xhr, originalBeforeSend;
 			var analyze = settings.nette = {

--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -340,7 +340,7 @@ $.nette.ext('validation', {
 		var div = document.createElement('div');
 		var all = div.getElementsByTagName('i');
 		while (
-        		div.innerHTML = '<!--[if gt IE ' + (++v) + ']><i></i><![endif]-->',
+			div.innerHTML = '<!--[if gt IE ' + (++v) + ']><i></i><![endif]-->',
 			all[0]
 		);
 		return v > 4 ? v : undefined;


### PR DESCRIPTION
Situation before:
when I called $.nette.ajax('http://example.com'), the internal jquery $.ajax('http://example.com') was processed successfully, however nette.ajax.js didn't wrapped it correctly (i.e. one of side effects was that 'before' event was not properly assigned and therefore not fired).

Fix:
if string is passed now, the settings object is converted: settings = {url: settings}, and now both nette.ajax.js and jquery is behaving proeprly.