### PR TITLE
Don't alter DOM if not necessary in applySnippet()

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -461,7 +461,7 @@ $.nette.ext('snippets', {
 			$el.append(html);
 		} else if (!back && $el.is('[data-ajax-prepend]')) {
 			$el.prepend(html);
-		} else {
+		} else if ($el.html() != html) {
 			$el.html(html);
 		}
 	},


### PR DESCRIPTION
This makes nette history plugin faster, as when `pushState()` occurs only DOM of changed snippets is updated.