### PR TITLE
Fix ajax forms without action attribute

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -176,7 +176,7 @@ var nette = function () {
 			}
 
 			if (!settings.url) {
-				settings.url = analyze.form ? analyze.form.attr('action') : ui.href;
+				settings.url = analyze.form ? analyze.form.attr('action') || window.location.pathname + window.location.search : ui.href;
 			}
 			if (!settings.type) {
 				settings.type = analyze.form ? analyze.form.attr('method') : 'get';


### PR DESCRIPTION
According to standard when action attribute is not specified it is considered to be the current URL. Currently nette.ajax.js is broken for such forms because it fails to analyze this case.

`window.location.href` didn't work for me for some reason. `window.location.pathname + window.location.search` did.