### PR TITLE
URL Validation Fix - Works also with absolute URLs incl. port number

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -329,7 +329,15 @@ $.nette.ext('validation', {
 
 		if (validate.url) {
 			// thx to @vrana
-			if (/:|^#/.test(analyze.form ? settings.url : analyze.el.attr('href'))) return false;
+			var urlToValidate = analyze.form ? settings.url : analyze.el.attr('href');
+			// Check if URL is absolute
+			if (/(?:^[a-z][a-z0-9+.-]*:|\/\/)/.test(urlToValidate)) {
+				// Parse absolute URL
+				var parsedUrl = new URL(urlToValidate);
+				if (/:|^#/.test(parsedUrl['pathname'] + parsedUrl['search'] + parsedUrl['hash'])) return false;
+			} else {
+				if (/:|^#/.test(urlToValidate)) return false;
+			}
 		}
 
 		if (!passEvent) {


### PR DESCRIPTION
Fixes issue when absolute URL is being provided and contains port number.
