### PR TITLE
Fix validation problem in Nette 2.4

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -319,8 +319,7 @@ $.nette.ext('validation', {
 			if (analyze.isSubmit || analyze.isImage) {
 				analyze.form.get(0)["nette-submittedBy"] = analyze.el.get(0);
 			}
-			var ie = this.ie();
-			if (analyze.form.get(0).onsubmit && analyze.form.get(0).onsubmit((typeof ie !== 'undefined' && ie < 9) ? undefined : e) === false) {
+			if ((analyze.form.get(0).onsubmit ? analyze.form.triggerHandler('submit') : Nette.validateForm(analyze.form.get(0))) === false) {
 				e.stopImmediatePropagation();
 				e.preventDefault();
 				return false;


### PR DESCRIPTION
Issue: https://github.com/vojtech-dobes/nette.ajax.js/issues/128

-------------------------------------------------------------
Problem is in validation in component:

$form->addInteger('hours', '')
->setRequired(TRUE)
->addRule(Form::RANGE, 'Zadejte počet hodin (%d až %d)', array(0, 99))<br/>
->setAttribute('class', 'form-control')<br/>
->setAttribute('placeholder', 'Počet hodin');
This rule is never call.

When is remove from form class ajax validation is OK.