### PR TITLE
Make it work with Nette 2.3 and older

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -315,7 +315,14 @@ $.nette.ext('validation', {
 			if (analyze.isSubmit || analyze.isImage) {
 				analyze.form.get(0)["nette-submittedBy"] = analyze.el.get(0);
 			}
-			if ((analyze.form.get(0).onsubmit ? analyze.form.triggerHandler('submit') : Nette.validateForm(analyze.form.get(0))) === false) {
+			var notValid;
+			if ((typeof Nette.version === 'undefined' || Nette.version == '2.3')) { // Nette 2.3 and older
+				var ie = this.ie();
+				notValid = (analyze.form.get(0).onsubmit && analyze.form.get(0).onsubmit((typeof ie !== 'undefined' && ie < 9) ? undefined : e) === false);
+			} else { // Nette 2.4 and up
+				notValid = ((analyze.form.get(0).onsubmit ? analyze.form.triggerHandler('submit') : Nette.validateForm(analyze.form.get(0))) === false)
+			}
+			if (notValid) {
 				e.stopImmediatePropagation();
 				e.preventDefault();
 				return false;


### PR DESCRIPTION
Fixes infinite loop caused in older versions of Nette. (Issue #134)
Warning. I have not tested it in all browsers or pretty much at all.
I only tested that it works with Ublaboo Datagrid ajax filtering in Chrome and Firefox.
