### PR TITLE
proper nette-forms independence

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -14,6 +14,8 @@
 if (typeof $ !== 'function') {
 	return console.error('nette.ajax.js: jQuery is missing, load it please');
 }
+// Optional nette-forms
+Nette = Nette || {};
 
 var nette = function () {
 	var inner = {


### PR DESCRIPTION
Now plugin fails to send AJAX forms, because `Nette` is undefined. It can handle an empty object just fine.