### PR TITLE
fix uploading files via ajax in Safari 11

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -404,18 +404,7 @@ $.nette.ext('forms', {
 		// https://developer.mozilla.org/en-US/docs/Web/Guide/Using_FormData_Objects#Sending_files_using_a_FormData_object
 		var formMethod = analyze.form.attr('method');
 		if (formMethod && formMethod.toLowerCase() === 'post' && 'FormData' in window) {
-			// clone form and remove empty file inputs as these causes Safari 11 to stall
-			// https://stackoverflow.com/questions/49672992/ajax-request-fails-when-sending-formdata-including-empty-file-input-in-safari
-			var clonedForm  = $.clone(analyze.form[0]);
-			for (i = 0; i < clonedForm.elements.length; i++) {
-				if (clonedForm.elements[i].type === 'file') {
-					if (clonedForm.elements[i].value === '') {
-						clonedForm.elements[i].parentNode.removeChild(clonedForm.elements[i]);
-					}
-				}
-			}
-
-			var formData = new FormData(clonedForm);
+			var formData = new FormData(analyze.form[0]);
 			for (var i in data) {
 				formData.append(i, data[i]);
 			}
@@ -423,6 +412,16 @@ $.nette.ext('forms', {
 			if (typeof originalData !== 'string') {
 				for (var i in originalData) {
 					formData.append(i, originalData[i]);
+				}
+			}
+			
+			// remove empty file inputs as these causes Safari 11 to stall
+			// https://stackoverflow.com/questions/49672992/ajax-request-fails-when-sending-formdata-including-empty-file-input-in-safari
+			if (formData.entries && navigator.userAgent.match(/version\/11(\.[0-9]*)? safari/i)) {
+				for (var pair of formData.entries()) {
+					if (pair[1] instanceof File && pair[1].name === '' && pair[1].size === 0) {
+						formData.delete(pair[0]);
+					}
 				}
 			}
 

--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -404,7 +404,18 @@ $.nette.ext('forms', {
 		// https://developer.mozilla.org/en-US/docs/Web/Guide/Using_FormData_Objects#Sending_files_using_a_FormData_object
 		var formMethod = analyze.form.attr('method');
 		if (formMethod && formMethod.toLowerCase() === 'post' && 'FormData' in window) {
-			var formData = new FormData(analyze.form[0]);
+			// clone form and remove empty file inputs as these causes Safari 11 to stall
+			// https://stackoverflow.com/questions/49672992/ajax-request-fails-when-sending-formdata-including-empty-file-input-in-safari
+			var clonedForm  = $.clone(analyze.form[0]);
+			for (i = 0; i < clonedForm.elements.length; i++) {
+				if (clonedForm.elements[i].type === 'file') {
+					if (clonedForm.elements[i].value === '') {
+						clonedForm.elements[i].parentNode.removeChild(clonedForm.elements[i]);
+					}
+				}
+			}
+
+			var formData = new FormData(clonedForm);
 			for (var i in data) {
 				formData.append(i, data[i]);
 			}


### PR DESCRIPTION
before form submission, clone form and remove empty file inputs as these causes Safari 11 to stall

https://stackoverflow.com/questions/49672992/ajax-request-fails-when-sending-formdata-including-empty-file-input-in-safari