### PR TITLE
Safari browser detection

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -417,7 +417,7 @@ $.nette.ext('forms', {
 			
 			// remove empty file inputs as these causes Safari 11 to stall
 			// https://stackoverflow.com/questions/49672992/ajax-request-fails-when-sending-formdata-including-empty-file-input-in-safari
-			if (formData.entries && navigator.userAgent.match(/version\/11(\.[0-9]*)? safari/i)) {
+			if (formData.entries && navigator.userAgent.match(/version\/11(\.[0-9]+)* safari/i)) {
 				for (var pair of formData.entries()) {
 					if (pair[1] instanceof File && pair[1].name === '' && pair[1].size === 0) {
 						formData.delete(pair[0]);


### PR DESCRIPTION
Correct regex for Safari detection

navigator.userAgent return 
Mozilla/5.0 (Macintosh; Intel Max OS X 10_12_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.**1**.**2** Safari/605.1.15