### PR TITLE
Hotfix: invalid-typeof-value error in webpack - typeof string must be 'boolean' and not 'bool' only

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -293,7 +293,7 @@ $.nette.ext('validation', {
 		var passEvent = false;
 		if (analyze.el.attr('data-ajax-pass') !== undefined) {
 			passEvent = analyze.el.data('ajaxPass');
-			passEvent = typeof passEvent === 'bool' ? passEvent : true;
+			passEvent = typeof passEvent === 'boolean' ? passEvent : true;
 		}
 
 		if (validate.keys) {

--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -418,7 +418,7 @@ $.nette.ext('forms', {
 			// remove empty file inputs as these causes Safari 11 to stall
 			// https://stackoverflow.com/questions/49672992/ajax-request-fails-when-sending-formdata-including-empty-file-input-in-safari
 			if (formData.entries && navigator.userAgent.match(/version\/11(\.[0-9]*)? safari/i)) {
-				for (var pair of formData.entries()) {
+				for (var pair in formData.entries()) {
 					if (pair[1] instanceof File && pair[1].name === '' && pair[1].size === 0) {
 						formData.delete(pair[0]);
 					}


### PR DESCRIPTION
I set up webpack for the new project in the company and as we're using Nette Framework I add also nette.ajax.js through yarn into the project and require this library in webpack. In development mode everything worked fine and I had no issues, but in the production build, the webpack through compilation always died with a stupid unclear message: 

ERROR in unknown: Invalid typeof value

After a couple of hours searching where just it could be I got into nette.ajax.js - when required then it has been destroying the build. So I started to search a bit more in the code following this:

https://github.com/jamesallardice/jslint-error-explanations/blob/master/message-articles/invalid-typeof-value.md

and I have found one place where was the comparison against "bool" and not "boolean". I repair it to "boolean" and since then compilation is working fine...