### PR TITLE
Pass state between requests

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -546,7 +546,15 @@ $.nette.ext('state', {
         let params = '';
 
         for (let [key, value] of Object.entries(Object.assign(this.state || {}, decodeURLParams(oldUrl)))) {
-            params += key + '=' + (encodeURIComponent(value) || '') + '&';
+            if (Array.isArray(value)) {
+                for (let arrayValue of value) {
+                    params += encodeURIComponent(key + '[]') + '=' + encodeURIComponent(arrayValue || '') + '&';
+                }
+
+                continue;
+            }
+
+            params += encodeURIComponent(key) + '=' + encodeURIComponent(value || '') + '&';
         }
 
         settings.url = baseUrl + (params ? ('?' + params) : '');

--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -554,13 +554,21 @@ $.nette.ext('state', {
             for (let [key, value] of Object.entries(allParams)) {
                 if (Array.isArray(value)) {
                     for (let arrayValue of value) {
-                        paramString += encodeURIComponent(key + '[]') + '=' + encodeURIComponent(arrayValue || '') + '&';
+                        paramString += ''.concat(key, encodeURIComponent('[]'), '=', encodeURIComponent(arrayValue || ''), '&');
                     }
 
                     continue;
                 }
 
-                paramString += encodeURIComponent(key) + '=' + encodeURIComponent(value || '') + '&';
+                if (value !== null && typeof value === 'object') {
+                    for (let [arrayKey, arrayValue] of Object.entries(value)) {
+                        paramString += ''.concat(key, encodeURIComponent('['.concat(arrayKey, ']')), '=', encodeURIComponent(arrayValue || ''), '&');
+                    }
+
+                    continue;
+                }
+
+                paramString += ''.concat(key, '=', encodeURIComponent(value || ''), '&');
             }
 
             return paramString ? ('?' + paramString) : paramString;

--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -561,7 +561,7 @@ $.nette.ext('state', {
     },
 	success: function (payload) {
 		if (payload.state) {
-			this.state = Object.assign(this.state || {}, payload.state);
+			this.state = payload.state;
 		}
 	}
 }, {state: null});

--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -512,7 +512,7 @@ $.nette.ext('redirect', {
 
 // current page state
 $.nette.ext('state', {
-    before: function (xhr, settings) {
+    prepare: function (settings) {
         if (settings.noState || $(settings.el).data('ajax-no-state')) {
             return;
         }
@@ -540,11 +540,11 @@ $.nette.ext('state', {
         };
 
         const oldUrl = settings.url;
-        const baseUrl = oldUrl.slice(0, oldUrl.indexOf("?") + 1);
+        const baseUrl = oldUrl.slice(0, oldUrl.indexOf("?"));
         let params = '';
 
         for (let [key, value] of Object.entries(Object.assign(this.state || {}, decodeURLParams(oldUrl)))) {
-            params += key + '=' + (value || '');
+            params += key + '=' + (encodeURIComponent(value) || '') + '&';
         }
 
         settings.url = baseUrl + (params ? ('?' + params) : '');

--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -518,11 +518,13 @@ $.nette.ext('state', {
         }
 
         const decodeURLParams = fullUrl => {
-            if (oldUrl.indexOf("?") === -1) {
+            const queryIndex = oldUrl.indexOf("?");
+
+            if (queryIndex === -1) {
                 return {};
             }
 
-            const hashes = fullUrl.slice(oldUrl.indexOf("?") + 1).split("&");
+            const hashes = fullUrl.slice(queryIndex + 1).split("&");
             return hashes.reduce((params, hash) => {
                 const split = hash.indexOf("=");
 

--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -520,7 +520,7 @@ $.nette.ext('state', {
         const getBaseUrl = fullUrl => {
             const queryIndex = oldUrl.indexOf("?");
             return queryIndex >= 0
-                ? oldUrl.slice(0, queryIndex + 1)
+                ? oldUrl.slice(0, queryIndex)
                 : oldUrl;
         };
 

--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -517,6 +517,13 @@ $.nette.ext('state', {
             return;
         }
 
+        const getBaseUrl = fullUrl => {
+            const queryIndex = oldUrl.indexOf("?");
+            return queryIndex >= 0
+                ? oldUrl.slice(0, queryIndex + 1)
+                : oldUrl;
+        };
+
         const decodeURLParams = fullUrl => {
             const queryIndex = oldUrl.indexOf("?");
 
@@ -541,23 +548,29 @@ $.nette.ext('state', {
             }, {});
         };
 
-        const oldUrl = settings.url;
-        const baseUrl = oldUrl.slice(0, oldUrl.indexOf("?"));
-        let params = '';
+        const encodeURLParams = allParams => {
+            let paramString = '';
 
-        for (let [key, value] of Object.entries(Object.assign(this.state || {}, decodeURLParams(oldUrl)))) {
-            if (Array.isArray(value)) {
-                for (let arrayValue of value) {
-                    params += encodeURIComponent(key + '[]') + '=' + encodeURIComponent(arrayValue || '') + '&';
+            for (let [key, value] of Object.entries(allParams)) {
+                if (Array.isArray(value)) {
+                    for (let arrayValue of value) {
+                        paramString += encodeURIComponent(key + '[]') + '=' + encodeURIComponent(arrayValue || '') + '&';
+                    }
+
+                    continue;
                 }
 
-                continue;
+                paramString += encodeURIComponent(key) + '=' + encodeURIComponent(value || '') + '&';
             }
 
-            params += encodeURIComponent(key) + '=' + encodeURIComponent(value || '') + '&';
-        }
+            return paramString ? ('?' + paramString) : paramString;
+        };
 
-        settings.url = baseUrl + (params ? ('?' + params) : '');
+        const oldUrl = settings.url;
+        const baseUrl = getBaseUrl(oldUrl);
+        const newParams = encodeURLParams(Object.assign(this.state || {}, decodeURLParams(oldUrl)));
+
+        settings.url = baseUrl + newParams;
     },
 	success: function (payload) {
 		if (payload.state) {


### PR DESCRIPTION
- Remebers states recieved from nette (merge array instead of replace).
- Updates URL to add all persistent paramers.
- Can be disabled using settings `noState` or data attribute `data-no-state`.

Some work is still needed to detect when nette drops parameter (-> uses default one).

Its big BC break. I am just leaving it here for anyone interested.